### PR TITLE
Handle falsey server_create parameters

### DIFF
--- a/vultr.py
+++ b/vultr.py
@@ -57,9 +57,9 @@ class Driver(object):
         if hostname:  data['hostname'] = hostname
         if tag:  data['tag'] = tag
         if reserved_ip_v4:  data['reserved_ip_v4'] = reserved_ip_v4
-        if auto_backups:  data['auto_backups'] = self.yn(auto_backups)
-        if ddos_protection:  data['ddos_protection'] = self.yn(ddos_protection)
-        if notify_activate:  data['notify_activate'] = self.yn(notify_activate)
+        data['auto_backups'] = self.yn(auto_backups)
+        data['ddos_protection'] = self.yn(ddos_protection)
+        data['notify_activate'] = self.yn(notify_activate)
 
         r = requests.post(self.API_BASE_URL + '/server/create', params={'api_key': self.API_KEY}, data=data)
 


### PR DESCRIPTION
For request parameters that accept a yes|no value, the server_create method would only include them if the values are truthy. This fix aims at including them with every request and using the included "yn" method to handle sending the correct value.